### PR TITLE
fixing heading to be h1 tag for doc search

### DIFF
--- a/src/preview.js
+++ b/src/preview.js
@@ -166,7 +166,7 @@ export default function Preview(props) {
         </Link>
       </Logo>
       <Header>
-        <Name>{nameValue}</Name>
+        <h1>{nameValue}</h1>
         <Reference href={reference} target="_blank">
           {reference}
         </Reference>


### PR DESCRIPTION
@Raathigesh for the purpose of https://github.com/Raathigesh/hooks.guide/issues/4 - Doc Search, I have changed our heading to be normal `h1` tag.

Because of this the ui would look slightly different, but this would help us in `Doc-Search.`

What do you think of about it?

Attaching before and after screenshots.
`Before adding h1 tag`

<img width="1440" alt="screenshot 2018-11-04 at 1 54 49 am" src="https://user-images.githubusercontent.com/4931048/47957029-c79fce80-dfd4-11e8-94be-df595e947960.png">


`After adding h1 tag`

<img width="1440" alt="screenshot 2018-11-04 at 1 54 39 am" src="https://user-images.githubusercontent.com/4931048/47957026-ab039680-dfd4-11e8-8c26-e9f01941fc57.png">
