### PR TITLE
fix an error in useReducer

### DIFF
--- a/public/docs/built-in/use-reducer.md
+++ b/public/docs/built-in/use-reducer.md
@@ -26,7 +26,7 @@ function reducer(state, action) {
   }
 }
 
-function Demo({initialState}) {
+function Demo() {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <>


### PR DESCRIPTION
There's no props specified for Demo component in ```executor.js```, so Demo shouldn't use any props, otherwise those props will be ```undefined```. 

In useReducer, ```initialState``` is just ```undefined``` in that way. and when try to use ```state.count```, there will be an ```Uncaught TypeError: Cannot read property 'count' of undefined```.