### PR TITLE
Add classes for docs. Should fix #4

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -78,11 +78,13 @@ export default function() {
         .filter(([key]) => key !== "community")
         .map(([key, value]) => {
           return (
-            <div>
-              <SectionHeader>{key}</SectionHeader>
+            <div className="docs-nav-section-group">
+              <SectionHeader className="docs-nav-section-header">
+                {key}
+              </SectionHeader>
               {value.map(item => {
                 return (
-                  <Item>
+                  <Item className="docs-nav-section-item">
                     <NavLink
                       activeStyle={{ color: highlightColor }}
                       to={`/${key}/${item.name}`}
@@ -96,11 +98,13 @@ export default function() {
           );
         })}
       {
-        <div>
-          <SectionHeader>Community</SectionHeader>
+        <div className="docs-nav-section-group">
+          <SectionHeader className="docs-nav-section-header">
+            Community
+          </SectionHeader>
           {hooks.community.map(item => {
             return (
-              <Item>
+              <Item className="docs-nav-section-item">
                 <Link to={`/community/${item.name}`}>{item.name}</Link>
               </Item>
             );

--- a/src/preview.js
+++ b/src/preview.js
@@ -175,12 +175,19 @@ export default function Preview(props) {
         </Link>
       </Logo>
       <Header>
-        <h1>{nameValue}</h1>
-        <Reference href={reference} target="_blank">
+        <h1 className="docs-content-header">{nameValue}</h1>
+        <Reference
+          className="docs-content-reference-link"
+          href={reference}
+          target="_blank"
+        >
           {reference}
         </Reference>
       </Header>
-      <div dangerouslySetInnerHTML={{ __html: description }} />
+      <div
+        className="docs-content-description"
+        dangerouslySetInnerHTML={{ __html: description }}
+      />
       {hookValue && (
         <React.Fragment>
           <Editor


### PR DESCRIPTION
Adds CSS classes prefixed with `docs-` so the content is indexable for documentation search.