### PR TITLE
Prevent content from jumping when hovering navigation links

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -52,17 +52,24 @@ const SectionHeader = styled.div`
   margin: 30px 0 10px;
 `;
 
-const Item = styled.div`
+const Item = styled(NavLink)`
   cursor: pointer;
+  display: block;
+  color: black;
+  text-decoration: none;
 
-  a {
-    color: black;
+  &:hover {
+    font-weight: 700;
+    color: ${highlightColor};
+  }
 
-    text-decoration: none;
-    &:hover {
-      font-weight: 700;
-      color: ${highlightColor};
-    }
+  &::after {
+    display: block;
+    content: "${props => props.children}";
+    font-weight: 700;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
   }
 `;
 
@@ -84,13 +91,12 @@ export default function() {
               </SectionHeader>
               {value.map(item => {
                 return (
-                  <Item className="docs-nav-section-item">
-                    <NavLink
-                      activeStyle={{ color: highlightColor }}
-                      to={`/${key}/${item.name}`}
-                    >
-                      {item.name}
-                    </NavLink>
+                  <Item
+                    className="docs-nav-section-item"
+                    activeStyle={{ color: highlightColor }}
+                    to={`/${key}/${item.name}`}
+                  >
+                    {item.name}
                   </Item>
                 );
               })}
@@ -104,8 +110,12 @@ export default function() {
           </SectionHeader>
           {hooks.community.map(item => {
             return (
-              <Item className="docs-nav-section-item">
-                <Link to={`/community/${item.name}`}>{item.name}</Link>
+              <Item
+                className="docs-nav-section-item"
+                activeStyle={{ color: highlightColor }}
+                to={`/community/${item.name}`}
+              >
+                {item.name}
               </Item>
             );
           })}


### PR DESCRIPTION
When you hover the longest link in the navigation (currently `useWindowMousePosition`),  the content jumps a little bit. This is caused by the fact that it needs more space when the text is bold and the layout changes.

This PR fixes this using a little CSS trick I learned some time ago which which adds the bold text with a height of 0px under the normal text so the wider version is already there when the text ist not hovered.
Also, with styled-components this is really easy because you can just make use of the children prop being passed!